### PR TITLE
Adds invocation samples to test-app

### DIFF
--- a/test-app/app/index.html
+++ b/test-app/app/index.html
@@ -13,7 +13,7 @@
 
     {{content-for "head-footer"}}
   </head>
-  <body>
+  <body class="test-app">
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/test-app/app/router.ts
+++ b/test-app/app/router.ts
@@ -9,4 +9,5 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('helpers-testing');
   this.route('helpers-testing-single-power-select');
+  this.route('power-select');
 });

--- a/test-app/app/routes/power-select.ts
+++ b/test-app/app/routes/power-select.ts
@@ -1,0 +1,21 @@
+import Route from '@ember/routing/route';
+
+export default class PowerSelectRoute extends Route {
+  model() {
+    // these are used only for presentation purposes in the test-app
+    const OPTIONS = [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+      'London (eu-west-2)',
+      'Frankfurt (eu-central-1)',
+    ];
+    const SELECTED = ['Oregon (us-west-2)'];
+    const SELECTEDMULTIPLE = [
+      'Oregon (us-west-2)',
+      'N. Virginia (us-east-1)',
+      'Ireland (eu-west-1)',
+    ];
+    return { OPTIONS, SELECTED, SELECTEDMULTIPLE };
+  }
+}

--- a/test-app/app/styles/app.scss
+++ b/test-app/app/styles/app.scss
@@ -1,1 +1,3 @@
-@import 'ember-power-select';
+@import "ember-power-select";
+
+@import "test-app";

--- a/test-app/app/styles/test-app.scss
+++ b/test-app/app/styles/test-app.scss
@@ -1,0 +1,31 @@
+.test-app {
+  font-family: system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.2;
+  margin: 0;
+  padding: 0;
+
+  h1 {
+    line-height: 1;
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.test-app-section {
+  width: 100%;
+
+  @media (width >= 48rem) {
+    width: 50%;
+    margin: 0 auto;
+  }
+}
+
+.test-app-power-select {
+  margin-bottom: 1rem;
+
+  p {
+    font-weight: 700;
+  }
+}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -1,3 +1,4 @@
-{{outlet}}
-
-<BasicDropdownWormhole />
+<main>
+  {{outlet}}
+  <BasicDropdownWormhole />
+</main>

--- a/test-app/app/templates/helpers-testing-single-power-select.hbs
+++ b/test-app/app/templates/helpers-testing-single-power-select.hbs
@@ -1,12 +1,10 @@
-<main>
-  <h1 class="t3">Helpers testing with single select</h1>
-  <div class="select-choose">
-    <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{fn (mut this.selected)}} @labelText="Label" @renderInPlace={{true}} @searchEnabled={{true}} as |num|>
-      {{num}}
-    </PowerSelect>
-  </div>
+<h1 class="t3">Helpers testing with single select</h1>
+<div class="select-choose">
+  <PowerSelect @options={{this.numbers}} @selected={{this.selected}} @onChange={{fn (mut this.selected)}} @labelText="Label" @renderInPlace={{true}} @searchEnabled={{true}} as |num|>
+    {{num}}
+  </PowerSelect>
+</div>
 
-  {{#if this.selected}}
-    <span class="select-choose-target">You've selected: {{this.selected}}</span>
-  {{/if}}
-</main>
+{{#if this.selected}}
+  <span class="select-choose-target">You've selected: {{this.selected}}</span>
+{{/if}}

--- a/test-app/app/templates/power-select.hbs
+++ b/test-app/app/templates/power-select.hbs
@@ -17,8 +17,7 @@
       {{option}}
     </PowerSelect>
   </div>
-
-  <hr />
+  
   <p>Selected</p>
 
   <div class="test-app-power-select">

--- a/test-app/app/templates/power-select.hbs
+++ b/test-app/app/templates/power-select.hbs
@@ -5,10 +5,10 @@
 <section class="test-app-section">
   <h2>Single selection</h2>
   <h3>Interaction</h3>
-  <p>Default</p>
 
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="Default"
       @options={{@model.OPTIONS}}
       @onChange={{fn (mut this.selected)}}
       @renderInPlace={{true}}
@@ -17,11 +17,10 @@
       {{option}}
     </PowerSelect>
   </div>
-  
-  <p>Selected</p>
 
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="Selected"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -31,10 +30,10 @@
       {{option}}
     </PowerSelect>
   </div>
-  <p>Search enabled</p>
 
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="Search enabled"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -48,10 +47,9 @@
 
   <h3>States</h3>
 
-  <p>Default</p>
-
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="States: Default"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -61,12 +59,11 @@
       {{option}}
     </PowerSelect>
   </div>
-
-  <p>Focus</p>
 
   <div class="test-app-power-select">
     <PowerSelect
       class="mock-focus"
+      @labelText="States: Focus"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -77,10 +74,9 @@
     </PowerSelect>
   </div>
 
-  <p>Disabled</p>
-
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="States: Disabled"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -94,9 +90,9 @@
 
   <h3>List position</h3>
 
-  <p>Below (default)</p>
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="List position: Below (default)"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -106,10 +102,10 @@
       {{option}}
     </PowerSelect>
   </div>
-  <p>Above</p>
 
   <div class="test-app-power-select">
     <PowerSelect
+      @labelText="List position: Above"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTED}}
       @onChange={{fn (mut this.selected)}}
@@ -124,10 +120,10 @@
   <h2>Multiple selection</h2>
 
   <h3>Interaction</h3>
-  <p>Default</p>
 
   <div class="test-app-power-select">
     <PowerSelectMultiple
+      @labelText="Default"
       @options={{@model.OPTIONS}}
       @onChange={{fn (mut this.selected)}}
       @renderInPlace={{true}}
@@ -136,10 +132,10 @@
       {{option}}
     </PowerSelectMultiple>
   </div>
-  <p>Selected</p>
 
   <div class="test-app-power-select">
     <PowerSelectMultiple
+      @labelText="Selected"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTEDMULTIPLE}}
       @onChange={{fn (mut this.selected)}}
@@ -149,10 +145,10 @@
       {{option}}
     </PowerSelectMultiple>
   </div>
-  <p>Search enabled</p>
 
   <div class="test-app-power-select">
     <PowerSelectMultiple
+      @labelText="Search enabled"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTEDMULTIPLE}}
       @onChange={{fn (mut this.selected)}}
@@ -166,10 +162,9 @@
 
   <h3>States</h3>
 
-  <p>Default</p>
-
   <div class="test-app-power-select">
     <PowerSelectMultiple
+      @labelText="States: Default"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTEDMULTIPLE}}
       @onChange={{fn (mut this.selected)}}
@@ -180,10 +175,11 @@
       {{option}}
     </PowerSelectMultiple>
   </div>
-  <p>Focus</p>
+
   <div class="test-app-power-select">
     <PowerSelectMultiple
       class="mock-focus"
+      @labelText="States: Focus"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTEDMULTIPLE}}
       @onChange={{fn (mut this.selected)}}
@@ -193,9 +189,10 @@
       {{option}}
     </PowerSelectMultiple>
   </div>
-  <p>Disabled</p>
+
   <div class="test-app-power-select">
     <PowerSelectMultiple
+      @labelText="States: Disabled"
       @options={{@model.OPTIONS}}
       @selected={{@model.SELECTEDMULTIPLE}}
       @onChange={{fn (mut this.selected)}}

--- a/test-app/app/templates/power-select.hbs
+++ b/test-app/app/templates/power-select.hbs
@@ -1,0 +1,211 @@
+{{page-title "PowerSelect Component"}}
+
+<h1>PowerSelect</h1>
+
+<section class="test-app-section">
+  <h2>Single selection</h2>
+  <h3>Interaction</h3>
+  <p>Default</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <hr />
+  <p>Selected</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+  <p>Search enabled</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      @searchEnabled={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <h3>States</h3>
+
+  <p>Default</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <p>Focus</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      class="mock-focus"
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <p>Disabled</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @disabled={{true}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <h3>List position</h3>
+
+  <p>Below (default)</p>
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+  <p>Above</p>
+
+  <div class="test-app-power-select">
+    <PowerSelect
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTED}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      @verticalPosition="above"
+      as |option|
+    >
+      {{option}}
+    </PowerSelect>
+  </div>
+
+  <h2>Multiple selection</h2>
+
+  <h3>Interaction</h3>
+  <p>Default</p>
+
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      @options={{@model.OPTIONS}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+  <p>Selected</p>
+
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTEDMULTIPLE}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+  <p>Search enabled</p>
+
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTEDMULTIPLE}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      @searchEnabled={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+
+  <h3>States</h3>
+
+  <p>Default</p>
+
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTEDMULTIPLE}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      @searchEnabled={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+  <p>Focus</p>
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      class="mock-focus"
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTEDMULTIPLE}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+  <p>Disabled</p>
+  <div class="test-app-power-select">
+    <PowerSelectMultiple
+      @options={{@model.OPTIONS}}
+      @selected={{@model.SELECTEDMULTIPLE}}
+      @onChange={{fn (mut this.selected)}}
+      @renderInPlace={{true}}
+      @disabled={{true}}
+      as |option|
+    >
+      {{option}}
+    </PowerSelectMultiple>
+  </div>
+
+</section>

--- a/test-app/tests/unit/routes/power-select-test.ts
+++ b/test-app/tests/unit/routes/power-select-test.ts
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'test-app/tests/helpers';
+
+module('Unit | Route | power-select', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:power-select');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
If merged, this PR adds invocations to test-app at `/power-select`. 

It adds a few styles scoped to `.test-app` so my eyes hurt less:

![CleanShot 2024-02-21 at 18 12 43@2x](https://github.com/alex-ju/ember-power-select/assets/4587451/d7451729-b868-461b-b490-2af9be437d9e)


